### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/evandroaraujomck/ccf00d95-3c83-455f-8eca-dcdb1ed2c598/dae08a8b-c819-4c7b-bdb9-b64d797bc6ea/_apis/work/boardbadge/d8362e80-0942-431e-9b6c-a2f77a79e546)](https://dev.azure.com/evandroaraujomck/ccf00d95-3c83-455f-8eca-dcdb1ed2c598/_boards/board/t/dae08a8b-c819-4c7b-bdb9-b64d797bc6ea/Microsoft.RequirementCategory)
 # Python_github
 Programa com perguntas aleatorias


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#2. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.